### PR TITLE
feat: implement getHLSRootFolderPath method in the Trait and update Q…

### DIFF
--- a/src/Jobs/QueueHLSConversion.php
+++ b/src/Jobs/QueueHLSConversion.php
@@ -48,7 +48,8 @@ final class QueueHLSConversion implements ShouldQueue
         CheckForDatabaseColumns::handle($this->model);
 
         $original_path = $this->model->getVideoPath();
-        $folderName = uuid_create();
+
+        $folderName = $this->model->getHLSRootFolderPath();
 
         ConvertToHLS::convertToHLS(
             $original_path,

--- a/src/Traits/ConvertsToHLS.php
+++ b/src/Traits/ConvertsToHLS.php
@@ -93,4 +93,9 @@ trait ConvertsToHLS
     {
         return property_exists($this, 'tempStorageOutputPath') ? $this->tempStorageOutputPath : config('hls.temp_storage_path', 'tmp');
     }
+
+    public function getHLSRootFolderPath(): string
+    {
+        return uuid_create();
+    }
 }


### PR DESCRIPTION
# HLS Media Output Folder Management

## Overview
In some cases, we have our content organized in different folders. With this implementation, we can use the function to update the name of our root folder using our Trait.

## Implementation Options

### Option 1: Generate Unique Folder with UUID
When you need a completely new unique folder structure:

```php
public function getHLSRootFolderPath()
{
    return 'musical-videos/'. Str::uuid();
}
```

This returns a unique folder for each file: `musical-videos/[uuid]`

### Option 2: Use Existing Media Library Path
When using the "spatie/laravel-medialibrary" library to organize and manage our content:

```php
public function getHLSRootFolderPath()
{
    $originalPath = $this->getPathRelativeToRoot();
    return dirname($originalPath);
}
```

This returns the existing folder where our files are located, which is already unique for each file based on the media library's organization structure.
